### PR TITLE
Fix deprecation warning: switch from React prop-types to using the prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-loader": "^1.3.0",
     "eslint-plugin-react": "^4.2.3",
     "pikaday": "^1.4.0",
+    "prop-types": "^15.5.10",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
     "sinon": "^1.17.3",

--- a/src/ReactPikadayComponent.js
+++ b/src/ReactPikadayComponent.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 let Pikaday;
 if ('undefined' !== typeof window) {


### PR DESCRIPTION
This fixes the console warning:

> Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.